### PR TITLE
Fix/6102 forbidden resource errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /coverage
 /node_modules
 test-report.xml
+
+.envrc

--- a/src/guards/auth.guard.ts
+++ b/src/guards/auth.guard.ts
@@ -49,7 +49,6 @@ export class AuthGuard implements CanActivate {
 
   async validateRequest(request): Promise<boolean> {
     const authHeader = request.headers.authorization;
-    console.log(authHeader);
     const forwardedForHeader = request.headers["x-forwarded-for"];
     let errorMsg =
       "Prior Authorization (User Security Token) required to access this resource.";

--- a/src/guards/auth.guard.ts
+++ b/src/guards/auth.guard.ts
@@ -49,6 +49,7 @@ export class AuthGuard implements CanActivate {
 
   async validateRequest(request): Promise<boolean> {
     const authHeader = request.headers.authorization;
+    console.log(authHeader);
     const forwardedForHeader = request.headers["x-forwarded-for"];
     let errorMsg =
       "Prior Authorization (User Security Token) required to access this resource.";

--- a/src/guards/roles.guard.ts
+++ b/src/guards/roles.guard.ts
@@ -10,7 +10,7 @@ import { Reflector } from "@nestjs/core";
 import { parseBool } from "../utilities";
 import { getManager } from "typeorm";
 import { LookupType } from "../enums";
-import { ValidatorParams } from "../interfaces";
+import { UserPermissionSet, ValidatorParams } from "../interfaces";
 import { EaseyException } from "../exceptions";
 
 @Injectable()
@@ -39,7 +39,7 @@ export class RolesGuard implements CanActivate {
         if (!checkedOutCriteria.has(item)) {
           console.log("Location not checked out!");
           return false;
-        } //
+        }
       }
     }
 
@@ -55,7 +55,7 @@ export class RolesGuard implements CanActivate {
       return true;
     }
 
-    let monPlanIds = [item]; //Default assumption is that this is a monPlanId
+    let monPlanIds = [item]; // Default assumption is that this is a monPlanId
     if (lookupType === LookupType.Location) {
       const data = await this.returnManager().query(
         `SELECT mon_plan_id 
@@ -98,7 +98,6 @@ export class RolesGuard implements CanActivate {
     return true;
   }
 
-  //
   // Find the corresponding request parameter and check to see if the user has permissions
   async handlePathParamValidation(
     context: ExecutionContext,
@@ -315,7 +314,6 @@ export class RolesGuard implements CanActivate {
       }
     }
 
-    const facilities = request.user.facilities;
     const lookupType = this.reflector.get<number>(
       "lookupType",
       context.getHandler()
@@ -325,17 +323,20 @@ export class RolesGuard implements CanActivate {
       "params",
       context.getHandler()
     );
+
+    // Check a user's role, and determine if they can access a resource
+    const roles = request.user.roles ?? [];
     if (params.requiredRoles) {
       if (
         params.requiredRoles.includes("ECMPS Admin") &&
-        request.user.roles.includes("ECMPS Admin")
+        roles.includes("ECMPS Admin")
       ) {
-        return true; //In the case the user has the required ECMPS admin role, let them through without performing other checks
+        return true; // In the case the user has the required ECMPS admin role, let them through without performing other checks
       }
 
       let containsARole = false;
       for (const requiredRole of params.requiredRoles) {
-        if (request.user.roles && request.user.roles.includes(requiredRole)) {
+        if (roles.includes(requiredRole)) {
           containsARole = true;
           break;
         }
@@ -346,24 +347,23 @@ export class RolesGuard implements CanActivate {
       }
     }
 
-    //2) Check a users role, and determine if they can access a resource
-    //3) Check a users permissions for a facility and see if they can edit / submit a facility
-
+    // Check a users permissions for a facility and see if they can edit / submit a facility
+    const facilities: UserPermissionSet[] = request.user.facilities;
     const facilitiesWithRole = facilities
       .filter((f) => {
-        if (params.permissionsForFacility) {
-          for (const permission of params.permissionsForFacility) {
-            if (f.permissions.includes(permission)) {
-              return true;
-            }
+        // An empty array is returned from the permissions API if the user's only role is "Preparer": this should be interpreted to mean that they can perform any "preparer" activities for their list of facilities.
+        if (roles.length === 1 && roles[0] === "Preparer") return true;
+        if (!params.permissionsForFacility) return true;
+        for (const permission of params.permissionsForFacility) {
+          if (f.permissions.includes(permission)) {
+            return true;
           }
-          return false;
         }
-        return true;
+        return false;
       })
       .map((p) => p.orisCode.toString());
 
-    let enforceCheckout = true; //Determine if thise endpoint needs to enforce that all records are also currently checked out
+    let enforceCheckout = true; // Determine if thise endpoint needs to enforce that all records are also currently checked out
     if (this.configService.get<boolean>("app.enableRoleGuardCheckoutCheck")) {
       if (
         params.enforceCheckout !== null &&
@@ -376,11 +376,11 @@ export class RolesGuard implements CanActivate {
       enforceCheckout = false;
     }
 
-    //Determine if location is checked out
+    // Determine if location is checked out
     let checkedOutCriteria;
     if (enforceCheckout) {
       if (lookupType === LookupType.MonitorPlan) {
-        //Pull back all of our checked out monitor plans
+        // Pull back all of our checked out monitor plans
         checkedOutCriteria = await this.returnManager().query(
           "SELECT mon_plan_id FROM camdecmpswks.user_check_out WHERE checked_out_by = $1",
           [request.user.userId]
@@ -457,7 +457,7 @@ export class RolesGuard implements CanActivate {
           const stackPipeSet = new Set();
 
           for (const locationChunk of chunk) {
-            //Perform validation of the data
+            // Perform validation of the data
             unitSet.add(locationChunk["unitId"]);
             stackPipeSet.add(locationChunk["stackPipeId"]);
           }
@@ -495,7 +495,7 @@ export class RolesGuard implements CanActivate {
       return true;
     }
 
-    //Determine the validation that needs to get executed. In the case there is none, return true, and use the unpacked list of accesible location / plan / facility data from the decorators
+    // Determine the validation that needs to get executed. In the case there is none, return true, and use the unpacked list of accesible location / plan / facility data from the decorators
     if (params.pathParam) {
       return this.handlePathParamValidation(
         context,


### PR DESCRIPTION
## Related Issues:
* [#6102](https://github.com/US-EPA-CAMD/easey-ui/issues/6102)

## Main Changes:
* Added an additional check to the role guard to handle the edge case where the user's only role is "Preparer": in this case, an empty array will be returned for facility permissions, although the APIs instructed the role guard to expect a `DP<MP|QA|EM>` permission.

## Steps To Test:
1. For the `easey-auth-api`, keep mock permissions enabled but set `EASEY_AUTH_API_ENABLE_ALL_FACILITIES=false`.
2. For the `easey-qa-certification-api`, set the following variables:
```
EASEY_QA_CERTIFICATION_API_ENABLE_AUTH_TOKEN=false
EASEY_QA_CERTIFICATION_API_CURRENT_USER='{ "facilities": [{ "facId": 1360, "orisCode": 55233, "permissions": [] }, { "facId": 121, "orisCode": 628, "permissions": [] } ], "roles": [ "Preparer" ], "userId": "<user_dp>" }'
```
replacing `<user_dp>` with your user that has a "Preparer" role (and **only** that role).
4. In `easey-qa-certification-api/node_modules/@us-epa-camd/easey-common/guards/roles.guard.js`, replace the variable assignment of `facilitiesWithRoles` with the following:
```
    const facilitiesWithRole = facilities
      .filter(f => {
        // An empty array is returned from the permissions API if the user's only role is "Preparer": this should be interpreted to mean that they can perform any "preparer" activities for their list of facilities.
        if (
          request.user.roles.length === 1 &&
          request.user.roles[0] === 'Preparer'
        )
          return true;
        if (!params.permissionsForFacility) return true;
        for (const permission of params.permissionsForFacility) {
          if (f.permissions.includes(permission)) {
            return true;
          }
        }
        return false;
      })
      .map(p => p.orisCode.toString());
```
This needs to be done in `node_modules` until this fix is pushed to the `npm` registry.
5. Start the `easey-ecmps-ui` application alongside the `easey-auth-api` and the `easey-qa-certification-api`
6. Log in with the "Preparer" user.
7. Navigate to the **Cert Events, Extensions & Exemptions** tab, then checkout the _EU-1A, EU-1B, EU-2A, EU-2B, EU-3A, EU-3B, EU-4A, EU-4B, EU-5A, EU-5B, CP100_ configuration of the facility with ORIS code _55233_ (Handsome Lake Energy).
8. Open the facility, click "Import Data", then "Import from File", then import the file [HAND_CP100_QA_Certification_EDR_Q1_2017.json](https://github.com/US-EPA-CAMD/easey-ui/files/14562219/HAND_CP100_QA_Certification_EDR_Q1_2017.json). Confirm it is imported successfully.
9. Check the facility back in, then navigate to **Test Data** and check out configuration _4_ of the facility with ORIS code _628_ (Crystal River).
10. Open the facility, click "Import Data", then "Import Historical Data". Select the reporting period _2023 Q3_, then click "Preview". Select any of the rows in the preview, then click "Import". Confirm the data is imported successfully.