### PR TITLE
fix: sellOwner comma change to pipe and remove extra space in ownerOp…

### DIFF
--- a/src/constants/property-metadata.constants.ts
+++ b/src/constants/property-metadata.constants.ts
@@ -2424,7 +2424,7 @@ export const propertyMetadata = {
     },
     description:
       "The name of any company that owns an allowance account or an affected unit.The name of any company that operates an affected unit.",
-    example: "Alabama Power Company (Operator) | Alabama Power Company (Owner)",
+    example: "Alabama Power Company (Operator)|Alabama Power Company (Owner)",
   },
   ownId: {
     fieldLabels: {
@@ -2618,7 +2618,7 @@ export const propertyMetadata = {
     },
     description:
       "The owner of the account transferring allowances in an allowance transaction.",
-    example: "AEP Generation Resources, Inc., Buckeye Power, Inc.",
+    example: "AEP Generation Resources, Inc.|Buckeye Power, Inc.",
   },
   sellSourceCategory: {
     fieldLabels: {


### PR DESCRIPTION
## Ticket
[Change delimiter in OwnerOperator](https://github.com/US-EPA-CAMD/easey-ui/issues/4888)

## Change

- ownerOperatorInfo's remove extra space
- sellOwner add pipe instead of comma