### PR TITLE
Fix/6215 preparers with more roles

### DIFF
--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -18,4 +18,5 @@ export { State } from "./state.enum";
 export { TransactionType } from "./transaction-type.enum";
 export { UnitFuelType } from "./unit-fuel-type.enum";
 export { UnitType } from "./unit-type.enum";
+export { UserRole } from "./user-role.enum";
 export { LookupType } from "./lookup-type.enum";

--- a/src/enums/user-role.enum.ts
+++ b/src/enums/user-role.enum.ts
@@ -1,0 +1,8 @@
+export enum UserRole {
+  ADMIN = "ECMPS Admin",
+  ANALYST = "ECMPS Analyst",
+  INITIAL_AUTHORIZER = "Initial Authorizer",
+  PREPARER = "Preparer",
+  SPONSOR = "Sponsor",
+  SUBMITTER = "Submitter",
+}

--- a/src/guards/roles.guard.ts
+++ b/src/guards/roles.guard.ts
@@ -352,7 +352,7 @@ export class RolesGuard implements CanActivate {
     const facilities: UserPermissionSet[] = request.user.facilities;
     const facilitiesWithRole = facilities
       .filter((f) => {
-        // An empty array is returned from the responsibilities API if the user's only role is "Preparer": it is implied that a Preparer role carries all preparer permissions for their list of facilities.
+        // An empty facility permissions array is returned from the responsibilities API if the user's only role is "Preparer": it is implied that a Preparer role carries all preparer permissions for their list of facilities.
         if (
           params.requiredRoles?.includes(UserRole.PREPARER) &&
           roles.includes(UserRole.PREPARER)

--- a/src/guards/roles.guard.ts
+++ b/src/guards/roles.guard.ts
@@ -9,7 +9,7 @@ import { ConfigService } from "@nestjs/config";
 import { Reflector } from "@nestjs/core";
 import { parseBool } from "../utilities";
 import { DataSource } from "typeorm";
-import { LookupType } from "../enums";
+import { LookupType, UserRole } from "../enums";
 import { UserPermissionSet, ValidatorParams } from "../interfaces";
 import { EaseyException } from "../exceptions";
 
@@ -329,8 +329,8 @@ export class RolesGuard implements CanActivate {
     const roles = request.user.roles ?? [];
     if (params.requiredRoles) {
       if (
-        params.requiredRoles.includes("ECMPS Admin") &&
-        roles.includes("ECMPS Admin")
+        params.requiredRoles.includes(UserRole.ADMIN) &&
+        roles.includes(UserRole.ADMIN)
       ) {
         return true; // In the case the user has the required ECMPS admin role, let them through without performing other checks
       }
@@ -352,8 +352,13 @@ export class RolesGuard implements CanActivate {
     const facilities: UserPermissionSet[] = request.user.facilities;
     const facilitiesWithRole = facilities
       .filter((f) => {
-        // An empty array is returned from the permissions API if the user's only role is "Preparer": this should be interpreted to mean that they can perform any "preparer" activities for their list of facilities.
-        if (roles.length === 1 && roles[0] === "Preparer") return true;
+        // An empty array is returned from the responsibilities API if the user's only role is "Preparer": it is implied that a Preparer role carries all preparer permissions for their list of facilities.
+        if (
+          params.requiredRoles?.includes(UserRole.PREPARER) &&
+          roles.includes(UserRole.PREPARER)
+        ) {
+          return true;
+        }
         if (!params.permissionsForFacility) return true;
         for (const permission of params.permissionsForFacility) {
           if (f.permissions.includes(permission)) {


### PR DESCRIPTION
## Main Changes

- Created a `UserRole` enum to use in place of string literals.
  - Moving forward, this enum should be used in place of `*_<SPONSOR | SUBMITTER | PREPARER | ANALYST | ADMIN>_ROLE` environment variables in other repositories.
- Updated the logic used by the role guard when a user has the "Preparer" role.