### PR TITLE
fix(6185): account for potentially null values with IsNull() helper

### DIFF
--- a/src/validators/db-lookup.validator.ts
+++ b/src/validators/db-lookup.validator.ts
@@ -4,7 +4,7 @@ import {
   ValidatorConstraintInterface,
 } from "class-validator";
 import { Injectable } from "@nestjs/common";
-import { BaseEntity, EntityManager } from "typeorm";
+import { BaseEntity, EntityManager, IsNull } from "typeorm";
 import { DbLookupOptions } from "../interfaces/validator-options.interface";
 
 @Injectable()
@@ -26,14 +26,14 @@ export class DbLookupValidator implements ValidatorConstraintInterface {
             {
               where: {
                 [this.entityManager.getRepository(type).metadata
-                  .primaryColumns[0].propertyName]: value,
+                  .primaryColumns[0].propertyName]: value ?? IsNull(),
               },
             }
           : // Use the provided find options.
             findOption?.(args) ?? {
               // Default to finding by the property with the same name.
               where: {
-                [args.property]: value,
+                [args.property]: value ?? IsNull(),
               },
             };
       const found = await this.entityManager.findOne(type, options);


### PR DESCRIPTION
## Main Changes

- The `IsNull()` helper must be explicitly used for `null` values in TypeORM `find*` methods version ^0.3.0.