### PR TITLE
fix: in bulk-load-stream added reject function in the finished Promise

### DIFF
--- a/src/bulk-load/bulk-load-stream.ts
+++ b/src/bulk-load/bulk-load-stream.ts
@@ -15,7 +15,11 @@ export class BulkLoadStream {
     this.hasWritten = false;
     this.stream = stream;
     this.status = "Writing";
-    this.finished = new Promise((resolve) => {
+    this.finished = new Promise((resolve, reject) => {
+      this.stream.on("error", (e) => {
+        reject(e.message);
+      });
+
       this.resolver = resolve;
     });
     this.client = client;


### PR DESCRIPTION
## Ticket
[Ensure that the user is notified when a database exception occurs during an import](https://github.com/US-EPA-CAMD/easey-ui/issues/6306)

## Changes

- Added reject to the finished promise, which will trigger when the stream error event calls.