### PR TITLE
Fix/5995 configuration manager

### DIFF
--- a/src/exceptions/cancel-transaction.exception.ts
+++ b/src/exceptions/cancel-transaction.exception.ts
@@ -1,5 +1,0 @@
-export class CancelTransactionException extends Error {
-  constructor() {
-    super('Transaction cancelled');
-  }
-}

--- a/src/exceptions/index.ts
+++ b/src/exceptions/index.ts
@@ -1,2 +1,1 @@
-export { CancelTransactionException } from './cancel-transaction.exception';
 export { EaseyException } from './easey.exception';

--- a/src/logger/Logger.service.ts
+++ b/src/logger/Logger.service.ts
@@ -46,20 +46,12 @@ export class Logger extends ConsoleLogger {
     }
   }
 
-  private getContext(): string | undefined {
-    return this.context;
-  }
-
   debug(message: any, ...optionalParams: [...any, string?]) {
-    const context =
-      typeof optionalParams[optionalParams.length - 1] === 'string'
-        ? optionalParams.pop()
-        : this.getContext();
-    super.debug(message, optionalParams, context);
+    super.debug(message, ...optionalParams);
     if (this.fileLogInstance) {
       this.fileLogInstance.debug(message, {
-        ...(context ? { context } : {}),
-        data: optionalParams,
+        ...(this.context ? { context: this.context } : {}),
+        ...(optionalParams.length ? { data: optionalParams } : {}),
       });
     }
   }


### PR DESCRIPTION
## Related Issues

- [#5995](https://github.com/US-EPA-CAMD/easey-ui/issues/5995)

## Main Changes

- Fixed an issue with changes I had made to the Logger, where Debug logs were printing an extra line.
- Removed the `CancelTransactionException`. The use of this was a bit of a hack, and I found a better (if more verbose) way to accomplish the same effect.