### PR TITLE
fix: numberOfTraversePointsWaf to numberOfTraversePointsWAF

### DIFF
--- a/src/constants/property-metadata.constants.ts
+++ b/src/constants/property-metadata.constants.ts
@@ -3432,7 +3432,7 @@ export const propertyMetadata = {
   ductWafDTONumberOfTraversePointsWAF: {
     fieldLabels: {
       label: 'Number of Traverse Points WAF',
-      value: 'numberOfTraversePointsWaf',
+      value: 'numberOfTraversePointsWAF',
     },
     description: 'The number of Method 1 traverse points in the WAF test runs.',
     example: 48,


### PR DESCRIPTION
## Ticket
[Update MP schema: numberOfTraversePointsWAF ](https://github.com/US-EPA-CAMD/easey-ui/issues/6329)

## Change

- Changed numberOfTraversePointsWaf to numberOfTraversePointsWAF in property-metadata constants for Swagger page example schema