### PR TITLE
fix: fixed handling of 'each' in custom validators

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@us-epa-camd/easey-common",
-  "version": "11.4.8",
+  "version": "11.4.9",
   "description": "Shared easey package",
   "main": "index.js",
   "types": "index.d.js",

--- a/src/validators/db-lookup.validator.ts
+++ b/src/validators/db-lookup.validator.ts
@@ -22,7 +22,9 @@ export class DbLookupValidator implements ValidatorConstraintInterface {
     if (value || !ignoreEmpty) {
       const found = await this.entityManager.findOne(
         type,
-        findOption?.(args) ?? {
+        // Assign only the value in question to the `value` property of the `validationArguments` parameter
+        // (if `each` is true on the decorator, `args.value` will differ from `value`).
+        findOption?.({ ...args, value }) ?? {
           where: {
             [args.property]: value ?? IsNull(),
           },

--- a/src/validators/is-valid-codes.validator.ts
+++ b/src/validators/is-valid-codes.validator.ts
@@ -25,7 +25,12 @@ export class IsValidCodesValidator implements ValidatorConstraintInterface {
         }
       }
       value = value.filter((v) => v !== "");
-      const found = await this.entityManager.find(type, findOption(args));
+      const found = await this.entityManager.find(
+        type,
+        // Assign only the value in question to the `value` property of the `validationArguments` parameter
+        // (if `each` is true on the decorator, `args.value` will differ from `value`).
+        findOption({ ...args, value })
+      );
       return found.length === value.length;
     }
     return true;


### PR DESCRIPTION
## Related Issues

- [#6290](https://github.com/US-EPA-CAMD/easey-ui/issues/6290)

## Main Changes

- Updated the `DbLookupValidator` and `IsValidCodesValidator` to pass only the value in question in the `validationArguments`, instead of (if `each` is `true` on the decorator) potentially an array of values. If required, the original array can still be accessed on the `object` property of the `ValidationArguments` along with the value of the `property` property:

```typescript
interface ValidationArguments {
    /**
     * Validating value.
     */
    value: any;
    /**
     * Constraints set by this validation type.
     */
    constraints: any[];
    /**
     * Name of the target that is being validated.
     */
    targetName: string;
    /**
     * Object that is being validated.
     */
    object: object;
    /**
     * Name of the object's property being validated.
     */
    property: string;
}

```