### PR TITLE
Fix/6386 validator each handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@us-epa-camd/easey-common",
-  "version": "17.5.2",
+  "version": "17.5.3",
   "description": "Shared easey package",
   "main": "index.js",
   "types": "index.d.js",

--- a/src/validators/db-lookup.validator.ts
+++ b/src/validators/db-lookup.validator.ts
@@ -2,13 +2,13 @@ import {
   ValidationArguments,
   ValidatorConstraint,
   ValidatorConstraintInterface,
-} from "class-validator";
-import { Injectable } from "@nestjs/common";
-import { BaseEntity, EntityManager, IsNull } from "typeorm";
-import { DbLookupOptions } from "../interfaces/validator-options.interface";
+} from 'class-validator';
+import { Injectable } from '@nestjs/common';
+import { BaseEntity, EntityManager, IsNull } from 'typeorm';
+import { DbLookupOptions } from '../interfaces/validator-options.interface';
 
 @Injectable()
-@ValidatorConstraint({ name: "dbLookup", async: true })
+@ValidatorConstraint({ name: 'dbLookup', async: true })
 export class DbLookupValidator implements ValidatorConstraintInterface {
   constructor(private readonly entityManager: EntityManager) {}
 
@@ -21,7 +21,7 @@ export class DbLookupValidator implements ValidatorConstraintInterface {
 
     if (value || !ignoreEmpty) {
       const options =
-        findOption === "primary"
+        findOption === 'primary'
           ? // Find by the entity's primary key.
             {
               where: {
@@ -30,7 +30,9 @@ export class DbLookupValidator implements ValidatorConstraintInterface {
               },
             }
           : // Use the provided find options.
-            findOption?.(args) ?? {
+            // Assign only the value in question to the `value` property of the `validationArguments` parameter
+            // (if `each` is true on the decorator, `args.value` will differ from `value`).
+            findOption?.({ ...args, value }) ?? {
               // Default to finding by the property with the same name.
               where: {
                 [args.property]: value ?? IsNull(),

--- a/src/validators/is-valid-codes.validator.ts
+++ b/src/validators/is-valid-codes.validator.ts
@@ -25,7 +25,12 @@ export class IsValidCodesValidator implements ValidatorConstraintInterface {
         }
       }
       value = value.filter((v) => v !== "");
-      const found = await this.entityManager.find(type, findOption(args));
+      const found = await this.entityManager.find(
+        type,
+        // Assign only the value in question to the `value` property of the `validationArguments` parameter
+        // (if `each` is true on the decorator, `args.value` will differ from `value`).
+        findOption({ ...args, value })
+      );
       return found.length === value.length;
     }
     return true;


### PR DESCRIPTION
## Related Issues

- [#6386](https://github.com/US-EPA-CAMD/easey-ui/issues/6386)

## Main Changes

- Updated the `DbLookupValidator` and `IsValidCodesValidator` to pass only the value in question in the `validationArguments`, instead of (if `each` is `true` on the decorator) potentially an array of values. If required, the original array can still be accessed on the `object` property of the `ValidationArguments` along with the value of the `property` property:

```typescript
interface ValidationArguments {
    /**
     * Validating value.
     */
    value: any;
    /**
     * Constraints set by this validation type.
     */
    constraints: any[];
    /**
     * Name of the target that is being validated.
     */
    targetName: string;
    /**
     * Object that is being validated.
     */
    object: object;
    /**
     * Name of the object's property being validated.
     */
    property: string;
}

```