### PR TITLE
Feature/6425 configuration manager

### DIFF
--- a/src/guards/roles.guard.ts
+++ b/src/guards/roles.guard.ts
@@ -165,7 +165,7 @@ export class RolesGuard implements CanActivate {
           checkedOutCriteria
         )
       ) {
-        return lookupList.has(data[pathChunks[step]]);
+        return lookupList.has(data[pathChunks[step]].toString()); // The lookup list is a set of strings
       }
 
       return false;


### PR DESCRIPTION
## Related Issues:

- [#6426](https://github.com/US-EPA-CAMD/easey-ui/issues/6425)

## Main Changes:

- Fixed a type issue in the Roles guard: when the `LookupType` is `Facility`, permissible ORIS codes are compared against those passed in through parameters. They are first converted to strings to compare against URL parameters, but this doesn't account for POST requests, where numbers can be interpreted as such.