### PR TITLE
fix: update audit log generic error response

### DIFF
--- a/src/decorators/audit-log.decorator.ts
+++ b/src/decorators/audit-log.decorator.ts
@@ -9,12 +9,13 @@ export function AuditLog({
   label = '',
   omitFields = [],
   requestBodyOutFields = [],
+  requestHeadersOutFields = [],
   requestParamsOutFields = [],
   requestQueryOutFields = [],
   responseBodyOutFields = [],
 }: AuditLogMetadata = {}) {
   return applyDecorators(
-    SetMetadata(METADATA_KEY, { label, omitFields, requestBodyOutFields, requestParamsOutFields, requestQueryOutFields, responseBodyOutFields }),
+    SetMetadata(METADATA_KEY, { label, omitFields, requestBodyOutFields, requestHeadersOutFields, requestParamsOutFields, requestQueryOutFields, responseBodyOutFields }),
     UseInterceptors(LoggingInterceptor),
   );
 }

--- a/src/interceptors/logging.interceptor.ts
+++ b/src/interceptors/logging.interceptor.ts
@@ -64,17 +64,20 @@ export class LoggingInterceptor implements NestInterceptor {
                         }, status));
                     }
                     else {
+                        const status = error.status || 500;
+                        const message = error.message || 'Internal Server Error';
+
                         this.logger.info({
                             eventContext,
                             eventName,
                             eventOutcome: "Internal Server Error",
                             eventSource,
                             userId,
-                            moreInfo: { message: error.message }
+                            moreInfo: { message, statusCode: status }
                         });
 
                         // For other errors, log and return a generic error response
-                        return throwError(() => new HttpException('Internal Server Error', 500));
+                        return throwError(() => new HttpException({ statusCode: status, message, }, status));
                     }
                 }),
             );

--- a/src/interceptors/logging.interceptor.ts
+++ b/src/interceptors/logging.interceptor.ts
@@ -15,7 +15,7 @@ export class LoggingInterceptor implements NestInterceptor {
     ) { }
 
     intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
-        const { label, omitFields, requestBodyOutFields, requestParamsOutFields, requestQueryOutFields, responseBodyOutFields } = this.reflector.get<AuditLogMetadata>('auditLog', context.getHandler()) ?? {};
+        const { label, omitFields, requestBodyOutFields, requestHeadersOutFields, requestParamsOutFields, requestQueryOutFields, responseBodyOutFields } = this.reflector.get<AuditLogMetadata>('auditLog', context.getHandler()) ?? {};
 
         const httpContext = context.switchToHttp();
         const req = httpContext.getRequest();
@@ -39,7 +39,7 @@ export class LoggingInterceptor implements NestInterceptor {
                     eventOutcome: "Success",
                     eventSource,
                     userId,
-                    moreInfo: this.filterMoreInfo(req, response, responseBodyOutFields, requestBodyOutFields, requestParamsOutFields, requestQueryOutFields, omitFields),
+                    moreInfo: this.filterMoreInfo(req, response, responseBodyOutFields, requestBodyOutFields, requestParamsOutFields, requestQueryOutFields, requestHeadersOutFields, omitFields),
                 })
                 ), catchError((error: any) => {
                     if (error instanceof EaseyException) {
@@ -83,11 +83,49 @@ export class LoggingInterceptor implements NestInterceptor {
             );
     }
 
-    filterMoreInfo(request: any, response: unknown, responseBodyOutFields: AuditLogMetadata['responseBodyOutFields'], requestBodyOutFields: AuditLogMetadata['requestBodyOutFields'], requestParamsOutFields: AuditLogMetadata['requestParamsOutFields'], requestQueryOutFields: AuditLogMetadata['requestQueryOutFields'], omitFields: AuditLogMetadata['omitFields']) {
+    // Generalized function to get values from dynamic JSON structure
+    getValuesFromData(keyPath: string, data: unknown) {
+        let result = [];
+        let keys = keyPath.split('.');
+
+        // Helper function to traverse the object recursively
+        function traverse(currentObj, keyPathParts) {
+            // Base case: if there are no more parts to the keyPath, we're at the target level
+            if (keyPathParts.length === 0) {
+                if (currentObj !== undefined) {
+                    // Push the value of the current object to the result
+                    result.push(currentObj);
+                }
+            } else {
+                // Get the next key in the path
+                let nextKey = keyPathParts.shift();
+
+                // If the current object is an array, we need to process each item in the array
+                if (Array.isArray(currentObj)) {
+                    currentObj.forEach(item => {
+                        if (item && item[nextKey] !== undefined) {
+                            traverse(item[nextKey], [...keyPathParts]);
+                        }
+                    });
+                } else if (currentObj && currentObj[nextKey] !== undefined) {
+                    // If it's an object and the key exists, go deeper
+                    traverse(currentObj[nextKey], keyPathParts);
+                }
+            }
+        }
+
+        // Start the recursive traversal with the provided data and key path
+        traverse(data, keys);
+
+        return result;
+    }
+
+    filterMoreInfo(request: any, response: unknown, responseBodyOutFields: AuditLogMetadata['responseBodyOutFields'], requestBodyOutFields: AuditLogMetadata['requestBodyOutFields'], requestParamsOutFields: AuditLogMetadata['requestParamsOutFields'], requestQueryOutFields: AuditLogMetadata['requestQueryOutFields'], requestHeadersOutFields: AuditLogMetadata['requestHeadersOutFields'], omitFields: AuditLogMetadata['omitFields']) {
 
         const requestParams = request.params;
         const requestBody = request.body;
         const requestQuery = request.query;
+        const requestHeaders = request.headers;
 
         const getFieldValues = (
             fields: string[] | '*' | 'all' = [],
@@ -97,9 +135,21 @@ export class LoggingInterceptor implements NestInterceptor {
                 if (fields === '*' || fields === 'all') {
                     return data as Record<string, unknown>;
                 }
+
+                const dotIncludeList = fields.filter(field => field.includes('.'));
+                const obj = {}
+                for (let i = 0; i < dotIncludeList.length; i++) {
+                    const result = this.getValuesFromData(dotIncludeList[i], data)
+                    obj[dotIncludeList[i]] = result;
+                }
+
                 return Object.keys(data).reduce((acc, key) => {
                     if (fields.includes(key)) {
                         acc[key] = data[key];
+                    }
+
+                    if (Object.keys(obj).length > 0) {
+                        acc = { ...acc, ...obj }
                     }
                     return acc;
                 }, {});
@@ -111,7 +161,8 @@ export class LoggingInterceptor implements NestInterceptor {
             ...getFieldValues(requestParamsOutFields, requestParams),
             ...getFieldValues(requestBodyOutFields, requestBody),
             ...getFieldValues(requestQueryOutFields, requestQuery),
-            ...getFieldValues(responseBodyOutFields, response)
+            ...getFieldValues(responseBodyOutFields, response),
+            ...getFieldValues(requestHeadersOutFields, requestHeaders)
         }).reduce((acc, [key, value]) => {
             if (!omitFields?.includes(key)) {
                 acc[key] = value;

--- a/src/interfaces/reflector-metadata.interface.ts
+++ b/src/interfaces/reflector-metadata.interface.ts
@@ -2,6 +2,7 @@ export interface AuditLogMetadata {
   label?: string;
   omitFields?: string[];
   requestBodyOutFields?: string[] | '*' | 'all';
+  requestHeadersOutFields?: string[] | '*' | 'all';
   requestParamsOutFields?: string[] | '*' | 'all';
   requestQueryOutFields?: string[] | '*' | 'all';
   responseBodyOutFields?: string[] | '*' | 'all';


### PR DESCRIPTION
## Ticket
[Monitoring Plan API Audit Implementation](https://github.com/US-EPA-CAMD/easey-ui/issues/6462)

## Changes

- Update audit log generic error response
- I added the `requestHeadersOutFields` parameter to retrieve specific header values from the request.
- I added a new function to retrieve values from within the object. (this used in monitoring-plan import)


 **Note** : 
When I test monitoring plan revert end point with planId: `TWCORNEL5-C0E3879920A14159BAA98E03F1980A7A` I received 
 internal server error instead of actual error message. 