### PR TITLE
fix: add swagger decorator definitions 

### DIFF
--- a/src/utilities/swagger-decorator.const.ts
+++ b/src/utilities/swagger-decorator.const.ts
@@ -1,0 +1,35 @@
+import {
+  ApiBadRequestResponse,
+  ApiExcludeEndpoint,
+  ApiExcludeController,
+  ApiNotFoundResponse,
+} from '@nestjs/swagger';
+import { applyDecorators } from '@nestjs/common';
+import {getConfigValue} from "./functions";
+
+const env = getConfigValue('EASEY_CAMD_SERVICES_ENV', 'local-dev');
+const enableSwagger = [
+  'local-dev',
+  'dev', 'develop', 'development',
+  'tst','test', 'testing',
+  'staging', 'stage',
+  'perf', 'performance',
+].includes(env);
+
+export const BadRequestResponse = () =>
+  ApiBadRequestResponse({
+    description: 'Invalid Request',
+  });
+
+export const NotFoundResponse = () =>
+  ApiNotFoundResponse({
+    description: 'Resource Not Found',
+  });
+
+export function ApiExcludeControllerByEnv() {
+  return applyDecorators(ApiExcludeController(!enableSwagger));
+}
+
+export function ApiExcludeEndpointByEnv() {
+  return applyDecorators(ApiExcludeEndpoint(!enableSwagger));
+}


### PR DESCRIPTION
fix: add swagger decorator definitions for API visibility control (make APIs visible or hide them from the swagger page)