### PR TITLE
fix(6419): type error in the CheckCatalogService

### DIFF
--- a/src/check-catalog/check-catalog.service.ts
+++ b/src/check-catalog/check-catalog.service.ts
@@ -8,7 +8,7 @@ interface CheckItem {
   plugins: string[];
 }
 
-type FormattedValues = Record<string, string>;
+type FormattedValues = Record<string, any>;
 
 @Injectable()
 export class CheckCatalogService implements OnApplicationBootstrap {


### PR DESCRIPTION
## Related Issues:

- [#6416](https://github.com/US-EPA-CAMD/easey-ui/issues/6416)
- [#6417](https://github.com/US-EPA-CAMD/easey-ui/issues/6417)
- [#6418](https://github.com/US-EPA-CAMD/easey-ui/issues/6418)
- [#6419](https://github.com/US-EPA-CAMD/easey-ui/issues/6419)

## Main Changes:

- Fixed a type that was too strict in `check-catalog-service.ts`.