### PR TITLE
fix: disable Strict-Transport-Security from helmet

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "class-validator": "^0.14.0",
     "dotenv": "^10.0.0",
     "express": "^4.20.0",
-    "helmet": "^4.6.0",
+    "helmet": "^8.0.0",
     "json2csv": "^5.0.6",
     "pg": "^8.11.5",
     "pg-copy-streams": "^6.0.6",

--- a/src/nestjs/applyMiddleware.ts
+++ b/src/nestjs/applyMiddleware.ts
@@ -1,4 +1,4 @@
-import * as helmet from "helmet";
+import helmet from "helmet";
 import { json } from "body-parser";
 import { useContainer } from "class-validator";
 import { ConfigService } from "@nestjs/config";
@@ -58,6 +58,7 @@ export async function applyMiddleware(
           connectSrc: ["'self'", "api.epa.gov"],
         },
       },
+      strictTransportSecurity:false
     })
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,10 +3151,10 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-helmet@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/helmet/-/helmet-4.6.0.tgz#579971196ba93c5978eb019e4e8ec0e50076b4df"
-  integrity sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==
+helmet@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.0.0.tgz#05370fb1953aa7b81bd0ddfa459221247be6ea5c"
+  integrity sha512-VyusHLEIIO5mjQPUI1wpOAEu+wl6Q0998jzTxqUYGE45xCIcAxy3MsbEK/yyJUJ3ADeMoB6MornPH6GMWAf+Pw==
 
 highlight.js@^10.7.1:
   version "10.7.3"


### PR DESCRIPTION
## Ticket
[Strict-Transport-Security Multiple Header Entries (Non-compliant with Spec](https://github.com/US-EPA-CAMD/easey-ui/issues/6553)

## Changes

- Update helmet package 4.6.0 to 8.0.0
- Disabled the HSTS header

Note - To disable the Strict-Transport-Security header: : https://www.npmjs.com/package/helmet#strict-transport-security