### PR TITLE
fix: remove characters outside of JSON in audit event logs

### DIFF
--- a/src/interceptors/logging.interceptor.ts
+++ b/src/interceptors/logging.interceptor.ts
@@ -33,7 +33,7 @@ export class LoggingInterceptor implements NestInterceptor {
         return next
             .handle()
             .pipe(
-                tap((response) => this.logger.info({
+                tap((response) => this.logger.auditLog({
                     eventContext,
                     eventName,
                     eventOutcome: "Success",
@@ -49,7 +49,7 @@ export class LoggingInterceptor implements NestInterceptor {
                         const eventOutcome = response.error(status);
                         const metadata = error.metadata || {}
 
-                        this.logger.info({
+                        this.logger.auditLog({
                             eventContext,
                             eventName,
                             eventOutcome,
@@ -67,7 +67,7 @@ export class LoggingInterceptor implements NestInterceptor {
                         const status = error.status || 500;
                         const message = error.message || 'Internal Server Error';
 
-                        this.logger.info({
+                        this.logger.auditLog({
                             eventContext,
                             eventName,
                             eventOutcome: "Internal Server Error",

--- a/src/logger/Logger.service.ts
+++ b/src/logger/Logger.service.ts
@@ -6,15 +6,25 @@ const { createLogger, format, transports } = require('winston');
 export class Logger extends ConsoleLogger {
   private consoleLogInstance: ReturnType<typeof createLogger>;
   private fileLogInstance: ReturnType<typeof createLogger>;
+  private infoLogInstance: ReturnType<typeof createLogger>;
   private isDevelopment = false;
 
   constructor(private readonly configService: ConfigService) {
     super();
 
-    const { combine, json, metadata, prettyPrint, timestamp } = format;
+    const { colorize, combine, json, metadata, prettyPrint, printf, timestamp } = format;
 
     this.consoleLogInstance = createLogger({
       format: combine(json(), prettyPrint()),
+      transports: [new transports.Console({})],
+    });
+
+    const infoFormat = printf(({ message }) => {
+      return `${message}`;
+    });
+
+    this.infoLogInstance = createLogger({
+      format: combine(json(), colorize({ all: true }), infoFormat),
       transports: [new transports.Console({})],
     });
 
@@ -75,6 +85,6 @@ export class Logger extends ConsoleLogger {
   }
 
   info(message: any, ...optionalParams: [...any, string?]) {
-    super.log(JSON.stringify(message), ...optionalParams);
+    this.infoLogInstance.info(JSON.stringify(message), ...optionalParams)
   }
 }

--- a/src/logger/Logger.service.ts
+++ b/src/logger/Logger.service.ts
@@ -6,13 +6,13 @@ const { createLogger, format, transports } = require('winston');
 export class Logger extends ConsoleLogger {
   private consoleLogInstance: ReturnType<typeof createLogger>;
   private fileLogInstance: ReturnType<typeof createLogger>;
-  private infoLogInstance: ReturnType<typeof createLogger>;
+  private auditLogInstance: ReturnType<typeof createLogger>;
   private isDevelopment = false;
 
   constructor(private readonly configService: ConfigService) {
     super();
 
-    const { colorize, combine, json, metadata, prettyPrint, printf, timestamp } = format;
+    const { combine, json, metadata, prettyPrint, printf, timestamp } = format;
 
     this.consoleLogInstance = createLogger({
       format: combine(json(), prettyPrint()),
@@ -23,8 +23,8 @@ export class Logger extends ConsoleLogger {
       return `${message}`;
     });
 
-    this.infoLogInstance = createLogger({
-      format: combine(json(), colorize({ all: true }), infoFormat),
+    this.auditLogInstance = createLogger({
+      format: combine(json(), infoFormat),
       transports: [new transports.Console({})],
     });
 
@@ -85,6 +85,12 @@ export class Logger extends ConsoleLogger {
   }
 
   info(message: any, ...optionalParams: [...any, string?]) {
-    this.infoLogInstance.info(JSON.stringify(message), ...optionalParams)
+    super.log(JSON.stringify(message), ...optionalParams);
+  }
+
+  auditLog(message: any, ...optionalParams: [...any, string?]) {
+    if (this.configService.get<boolean>('app.enableAuditLog')) {
+      this.auditLogInstance.info(JSON.stringify(message), ...optionalParams);
+    }
   }
 }


### PR DESCRIPTION
## Ticket
[Remove characters outside of JSON in audit event logs](https://github.com/US-EPA-CAMD/easey-ui/issues/6643)

## Changes
To log info, create an `infoLogInstance` and used the `printf` method for logging messages.

 **Note**: Need to add `enableAuditLog: getConfigValueBoolean('EASEY_AUTH_API_ENABLE_AUDIT_LOG', true)` in service app.config.ts
