### PR TITLE
fix: audit log moreInfo

### DIFF
--- a/src/interceptors/logging.interceptor.ts
+++ b/src/interceptors/logging.interceptor.ts
@@ -122,10 +122,10 @@ export class LoggingInterceptor implements NestInterceptor {
 
     filterMoreInfo(request: any, response: unknown, responseBodyOutFields: AuditLogMetadata['responseBodyOutFields'], requestBodyOutFields: AuditLogMetadata['requestBodyOutFields'], requestParamsOutFields: AuditLogMetadata['requestParamsOutFields'], requestQueryOutFields: AuditLogMetadata['requestQueryOutFields'], requestHeadersOutFields: AuditLogMetadata['requestHeadersOutFields'], omitFields: AuditLogMetadata['omitFields']) {
 
-        const requestParams = request.params;
-        const requestBody = request.body;
-        const requestQuery = request.query;
-        const requestHeaders = request.headers;
+        const requestParams = Object.assign({}, request.params);
+        const requestBody = Object.assign({}, request.body);
+        const requestQuery = Object.assign({}, request.query);
+        const requestHeaders = Object.assign({}, request.headers);
 
         const getFieldValues = (
             fields: string[] | '*' | 'all' = [],


### PR DESCRIPTION
## Ticket
[Audit log moreInfo field not returning expected data due to Express 5 query/param parsing](https://github.com/US-EPA-CAMD/easey-ui/issues/6728)

## Changes
Used Object.assign to create shallow copies of request.params, request.body, request.query, and request.headers. 
