### PR TITLE
To remove prepack script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "lint": "eslint '*/**/*.{js,ts}' --quiet --fix",
     "semantic-release": "semantic-release",
     "postbuild": "node -e \"require('fs').copyFile('./package.json', './lib/package.json', (err) => { if (err) throw err; console.log('package.json copied to /lib'); })\"",
-    "postversion": "cp -r package.json ..",
-    "prepack": "rm -rf dist && yarn build"
+    "postversion": "cp -r package.json .."
   },
   "resolutions": {
     "xml2js": "^0.5.0"


### PR DESCRIPTION
To remove prepack script `"rm -rf dist && yarn build" ` from package.json, due to a potential conflict it may have created. 