### PR TITLE
Fix/6804 invalid OpenAPI

### DIFF
--- a/src/constants/property-metadata.constants.ts
+++ b/src/constants/property-metadata.constants.ts
@@ -5871,6 +5871,24 @@ export const propertyMetadata = {
     example: true,
   },
 
+  unitCapacityDTOBoilerTurbineBeginDate: {
+    fieldLabels: {
+      label: 'Boiler Turbine Begin Date',
+      value: 'boilerTurbineBeginDate',
+    },
+    description: 'Date on which monitoring began for a boiler or turbine unit.',
+    example: '2009-01-01',
+  },
+
+  unitCapacityDTOBoilerTurbineEndDate: {
+    fieldLabels: {
+      label: 'Boiler Turbine End Date',
+      value: 'boilerTurbineEndDate',
+    },
+    description: 'Date on which monitoring ended for a boiler or turbine unit.',
+    example: '2009-01-01',
+  },
+
   unitControlDTOId: {
     fieldLabels: {
       label: '',
@@ -6910,6 +6928,49 @@ export const propertyMetadata = {
     },
     description: "Indicates whether the unit program is currently active.",
     example: true,
+  },
+
+  userCheckOutDTO: {
+    checkedOutOn: {
+      fieldLabels: {
+        label: 'Checked Out On',
+        value: 'checkedOutOn',
+      },
+      description: 'The date and time when the monitor plan was checked out.',
+      example: '2023-10-01T12:00:00Z',
+    },
+    checkedOutBy: {
+      fieldLabels: {
+        label: 'Checked Out By',
+        value: 'checkedOutBy',
+      },
+      description: 'The user who checked out the monitor plan.',
+      example: 'abcdef',
+    },
+    facId: {
+      fieldLabels: {
+        label: 'Facility ID',
+        value: 'facId',
+      },
+      description: `The Facility ID code assigned by the Department of Energy's Energy Information Administration. The Energy Information Administration Plant ID code is also referred to as the "ORIS code", "ORISPL code", "Facility ID", or "Facility code", among other names. If a Plant ID code has not been assigned by the Department of Energy's Energy Information Administration, then plant code means a code beginning with "88" assigned by the EPA's Clean Air Markets Division for electronic reporting.`,
+      example: 3,
+    },
+    lastActivity: {
+      fieldLabels: {
+        label: 'Last Activity',
+        value: 'lastActivity',
+      },
+      description: "Date of a user's last checkout activity.",
+      example: '2023-10-01T00:00:00Z',
+    },
+    monPlanId: {
+      fieldLabels: {
+        label: '',
+        value: 'monPlanId',
+      },
+      description: 'Unique identifier of a monitor plan record.',
+      example: 'TWCORNEL5-C0E3879920A14159BAA98E03F1980A7A',
+    },
   },
 
   //Reporting frequency

--- a/src/nestjs/applySwagger.ts
+++ b/src/nestjs/applySwagger.ts
@@ -53,10 +53,8 @@ export async function applySwagger(app: INestApplication) {
   if (configService.get<boolean>("app.enableAuthToken")) {
     swaggerDocOptions.addBearerAuth(
       {
-        in: "header",
         type: "http",
         scheme: "bearer",
-        name: "Token",
         description:
           'Authorization "bearer" token required for data modification operations',
       },
@@ -67,13 +65,11 @@ export async function applySwagger(app: INestApplication) {
   if (configService.get<boolean>("app.enableClientToken")) {
     swaggerDocOptions.addBearerAuth(
       {
-        in: "header",
         type: "http",
         scheme: "bearer",
-        bearerFormat: "jwt",
-        name: "ClientToken",
+        bearerFormat: "JWT",
         description:
-          'Authorization "bearer" client jwt token required for api endpoints',
+          'Authorization "bearer" client JWT token required for api endpoints',
       },
       "ClientToken"
     );


### PR DESCRIPTION
## Related Issues:

- https://github.com/US-EPA-CAMD/easey-ui/issues/6803
- https://github.com/US-EPA-CAMD/easey-ui/issues/6804
- https://github.com/US-EPA-CAMD/easey-ui/issues/6805

## Main Changes:

- [Security Scheme Objects](https://spec.openapis.org/oas/v3.0.0.html#security-scheme-object) of type "http" are not allowed to have the properties `in` or `name`, since it always applies to the `Authorization` header. Those fields have now been removed from the "Token" and "ClientToken" objects.