### PR TITLE
fix: DB Health check now provides a configurable timeout value

### DIFF
--- a/src/constants/api-config.service.ts
+++ b/src/constants/api-config.service.ts
@@ -35,4 +35,8 @@ export class ApiConfigService {
     const host = this.getHost("EMISSIONS", 8040);
     return `${host}/emissions-mgmt`;
   }
+
+  public static getDbHealthTimeout(): number {
+    return Number(process.env.EASEY_DB_HEALTH_TIMEOUT) || 300000;
+  }
 }

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -5,6 +5,7 @@ import {
     HealthCheckService,
     TypeOrmHealthIndicator,
 } from '@nestjs/terminus';
+import { ApiConfigService } from '../constants';
 
 @Controller()
 export class HealthController {
@@ -17,7 +18,7 @@ export class HealthController {
     @HealthCheck()
     check() {
         return this.health.check([
-            () => this.db.pingCheck('database'),
+            () => this.db.pingCheck('database', { timeout: ApiConfigService.getDbHealthTimeout() }),
         ]);
     }
 }


### PR DESCRIPTION
fix: DB Health check now provides a configurable timeout value, defaults to 300000