### PR TITLE
Update dep. for #6897 - add quotes to regex patterns for valid PostgreSQL syntax

### DIFF
--- a/src/utilities/regex.ts
+++ b/src/utilities/regex.ts
@@ -11,7 +11,7 @@ export class Regex {
    */
   public static commaDelimited(str: string): string {
     const s = Regex.escape(str);
-    return `((^${s}$)|([,][ ]*${s}$)|([,][ ]*${s}[,])|(^${s}[,])|(^${s} [(])|([,][ ]*${s} [(]))`;
+    return `'((^${s}$)|([,][ ]*${s}$)|([,][ ]*${s}[,])|(^${s}[,])|(^${s} [(])|([,][ ]*${s} [(]))'`;
   }
 
   /**
@@ -19,7 +19,7 @@ export class Regex {
    */
   public static pipeDelimited(str: string): string {
     const s = Regex.escape(str);
-    return `((^${s}$)|([|][ ]*${s}$)|([|][ ]*${s}[|])|(^${s}[|])|(^${s} [(])|([|][ ]*${s} [(]))`;
+    return `'((^${s}$)|([|][ ]*${s}$)|([|][ ]*${s}[|])|(^${s}[|])|(^${s} [(])|([|][ ]*${s} [(]))'`;
   }
 
 }


### PR DESCRIPTION
Fixes #6897 - Control Technology filter requires quoted regex patterns for PostgreSQL ~* operator to work correctly. 
Without quotes, the SQL syntax is invalid and queries return no results.

